### PR TITLE
Add parent trace's 'error' to child, if present

### DIFF
--- a/py-sdk/src/forta_bot_sdk/traces/parse_debug_traces_and_logs.py
+++ b/py-sdk/src/forta_bot_sdk/traces/parse_debug_traces_and_logs.py
@@ -36,6 +36,8 @@ def provide_parse_debug_traces_and_logs() -> ParseDebugTracesAndLogs:
             trace_error = trace.get("error")
             if trace_error:
                 trace_dict['error'] = trace_error
+                for subtrace in trace.get("calls", []):
+                    subtrace['error'] = trace_error
             traces.append(Trace(trace_dict))
             # keep track of event logs
             if trace.get("logs"):


### PR DESCRIPTION
Logic to pass a trace's `"error"` property to child trace if present. Repeats with child traces until the "bottom".